### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/yinkaolotin/tjat/compare/v0.1.1...v0.1.2) - 2025-04-23
+
+### Fixed
+
+- fix a
+
 ## [0.1.0](https://github.com/yinkaolotin/tjat/releases/tag/v0.1.0) - 2025-04-22
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "yinkakai"
-version = "0.1.1"
+version = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yinkakai"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 license = "Apache-2.0"
 description = "productivity, in your terminal."

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 fn main() {
     println!("Hello, world!");
-    a();
+    b();
 }
 
-fn a() {
+fn b() {
     println!("aaa")
 }


### PR DESCRIPTION



## 🤖 New release

* `yinkakai`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/yinkaolotin/tjat/compare/v0.1.1...v0.1.2) - 2025-04-23

### Fixed

- fix a
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).